### PR TITLE
创建文章页面添加权限控制

### DIFF
--- a/application/controllers/v2/news.php
+++ b/application/controllers/v2/news.php
@@ -170,6 +170,12 @@ function getPageLinks($pageloc,$theurl,$totalrows , $per_page,$ext_info,$firstur
 
 public function create(){
 
+  $editors = $this->news_model->get_editors();
+  $username = $this->session->userdata('username');
+  if (strstr($editors, $username) == false) {
+    redirect('/v2/act/userinfo');
+  }
+
   $this->load->helper(array('form', 'url'));
   $this->load->library('form_validation');
 


### PR DESCRIPTION
1. 非编辑用户访问时跳转到登入页面，引导用户以编辑身份登入