### PR TITLE
解决首页头像显示异常

### DIFF
--- a/application/controllers/v2/upload_reg.php
+++ b/application/controllers/v2/upload_reg.php
@@ -17,7 +17,7 @@ class Upload_reg extends CI_Controller {
   $fileExt = pathinfo($_FILES['userfile']['name'], PATHINFO_EXTENSION);
   $sysid = $_POST['upload_fname'] ;
   $new_filename = $sysid .'.'. $fileExt;
-   log_message('error', 'Fname='. $sysid .'.'. $fileExt );
+  log_message('error', 'Fname='. $sysid .'.'. $fileExt );
 
   $config['upload_path'] = $_POST['upload_path'];
   $config['file_name'] = $new_filename ;
@@ -44,6 +44,8 @@ class Upload_reg extends CI_Controller {
 		$this->db->where('sysid', $sysid);
 		$this->db->update('act', $up_rec);
 
+        // 更新 session 中的头像，让首页可以直接看到效果
+	   $this->session->set_userdata('userpic', $new_filename);
  	   $this->load->view('v2/templates/header');
 	   $this->load->view('v2/reginfo/upload_success', $data);
 	   $this->load->view('v2/templates/footer');

--- a/application/views/v2/home.php
+++ b/application/views/v2/home.php
@@ -55,6 +55,9 @@ function getTimeShow($t) {
 	$username = $this->session->userdata('username');
 	$regtime = $this->session->userdata('regtime');
 	$userpic = $this->session->userdata('userpic');
+    if (strlen($userpic) < 6 || substr($userpic, -1) == '.') {
+        $userpic = 'null_pic.jpg';
+    }
 
 	if ( $username != FALSE ) {
 		       echo '<div class="panel-body"  style="text-align: center">' ;
@@ -64,7 +67,7 @@ function getTimeShow($t) {
 			   echo '     <li>注册：<span>'. $regtime . '</span></li>';
 			   echo ' </ul>' ;
 			   echo '</div>' ; 
-	}else { ?>
+	} else { ?>
 			<form action=/v2/act/login method=post>
             <div class="panel-body"> 
                 <div class="form-group clearfix">
@@ -118,7 +121,7 @@ function getTimeShow($t) {
                 <li class="list-group-item">
                     <div class="media-left">
                         <a href="#">
-                            <img class="media-object" src=/images/users/<?php echo strlen($nrec['picture']) < 6 ? "null_pic.jpg" : $nrec['picture'] ; ?> width="64px" height="64px"></img>
+                            <img class="media-object" src=/images/users/<?php echo (strlen($nrec['picture']) < 6 || substr($nrec['picture'], -1) == '.') ? "null_pic.jpg" : $nrec['picture'] ; ?> width="64px" height="64px"></img>
                         </a>
                     </div>
                     <div class="media-body">


### PR DESCRIPTION
主要是用户数超过10000之后，空头像的长度超过了预设的宽度6，补充规则以 . 结尾的算空头像