### PR TITLE
修正文档资料“new“角标的偏移，并避免将来发生同样的错误

### DIFF
--- a/application/views/v2/document/document.php
+++ b/application/views/v2/document/document.php
@@ -16,7 +16,7 @@
 
     </div>
     <!--右边内容部分-->
-    <div class="col-md-9">
+    <div id="documents" class="col-md-9">
         <div class="well">
             <!--分级导航-->
             <ol class="breadcrumb">

--- a/css/v2/style.css
+++ b/css/v2/style.css
@@ -117,6 +117,10 @@ nav a{
     background-color: #fff;
 }
 
+#documents .well {
+    position: relative;
+}
+
 .well .table{
     border: 1px solid #eee;
     /*table-layout: fixed;*/


### PR DESCRIPTION
文档目录页面 NEW 角标位置偏移，看历史记录，原来外部有过样式 position:relative，某次更新时漏掉了。
为了避免出现相同问题，将样式提取到样式表，确保将来更新文章时不会因为遗漏此样式而再发生偏移。